### PR TITLE
making use of from_cell_with_material

### DIFF
--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -969,7 +969,8 @@ class R2SModel(Model):
                 if cell.fill is None:
                     continue
                 src = openmc.Source.from_cell_with_material(cell)
-                src_list.append(src)
+                if src is not None:  # materials may have no photon emission
+                    src_list.append(src)
 
             self.settings.source = src_list
             self.export_to_xml(rundir)


### PR DESCRIPTION
work in progress, this won't work yet but nice to see the potential improvements

I think the r2smodel can be simplified by making use of the open [PR](ttps://github.com/openmc-dev/openmc/pull/2315) that adds ```from_cell_with_material``` class method.

Additionally this makes sure the source points are born within the cell which is a small improvement on the current version that makes sure the source points are created withing the cell bounding box

note to self, check if the cell needs the material setting to an entry in new_mats